### PR TITLE
Prevent shading of specific filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ require'shade'.setup({
     brightness_up    = '<C-Up>',
     brightness_down  = '<C-Down>',
     toggle           = '<Leader>s',
-  }
+  },
+  exclude_filetypes = { "neo-tree", "markdown" }
 })
 ```
 
 * The `keys` table above shows available actions. No mappings are defined by default.
 
 * The color of the numbers in the brightness control popup can be customized by creating a highlight group named: `ShadeBrightnessPopup` and setting the attributes to your liking.
+
+* The `exclude_filetypes` table above is just an example. No filetypes are excluded by default.
 
 ## License
 

--- a/lua/shade.lua
+++ b/lua/shade.lua
@@ -148,6 +148,33 @@ local function map_key(mode, key, action)
 end
 
 
+--
+
+local function is_filetype_excluded(filetype)
+    for _, value in ipairs(state.exclude_filetypes) do
+        if value == filetype then
+            return true
+        end
+
+    end
+    return false
+end
+
+local function can_shade(winid)
+    if #state.exclude_filetypes == 0 then
+        return true
+    end
+    local buf_id = vim.api.nvim_win_get_buf(winid)
+    local filetype = vim.api.nvim_buf_get_option(buf_id, "filetype")
+
+    if is_filetype_excluded(filetype) then
+        return false
+    end
+
+    return true
+end
+
+--
 
 local function shade_window(winid)
   local overlay = state.active_overlays[winid]
@@ -181,8 +208,10 @@ local function shade_tabpage(winid)
   for overlay_winid, _ in pairs(state.active_overlays) do
     local diff_enabled = api.nvim_win_get_option(overlay_winid, 'diff')
     if overlay_winid ~= winid and diff_enabled == false then
-      log("deactivating window", overlay_winid)
-      shade_window(overlay_winid)
+      if can_shade(overlay_winid) then
+        log("deactivating window", overlay_winid)
+        shade_window(overlay_winid)
+      end
     end
   end
 end
@@ -232,6 +261,7 @@ shade.init = function(opts)
                               E.DEFAULT_OVERLAY_OPACITY)
   state.opacity_step = opts.opacity_step or E.DEFAULT_OPACITY_STEP
   state.shade_under_float = opts.shade_under_float or true
+  state.exclude_filetypes = opts.exclude_filetypes or {}
 
   state.shade_nsid = api.nvim_create_namespace("shade")
 

--- a/lua/shade.lua
+++ b/lua/shade.lua
@@ -151,27 +151,27 @@ end
 --
 
 local function is_filetype_excluded(filetype)
-    for _, value in ipairs(state.exclude_filetypes) do
-        if value == filetype then
-            return true
-        end
-
+  for _, value in ipairs(state.exclude_filetypes) do
+    if value == filetype then
+      return true
     end
-    return false
+
+  end
+  return false
 end
 
 local function can_shade(winid)
-    if #state.exclude_filetypes == 0 then
-        return true
-    end
-    local buf_id = vim.api.nvim_win_get_buf(winid)
-    local filetype = vim.api.nvim_buf_get_option(buf_id, "filetype")
-
-    if is_filetype_excluded(filetype) then
-        return false
-    end
-
+  if #state.exclude_filetypes == 0 then
     return true
+  end
+  local buf_id = vim.api.nvim_win_get_buf(winid)
+  local filetype = vim.api.nvim_buf_get_option(buf_id, "filetype")
+
+  if is_filetype_excluded(filetype) then
+    return false
+  end
+
+  return true
 end
 
 --

--- a/lua/shade.lua
+++ b/lua/shade.lua
@@ -242,7 +242,9 @@ local function create_tabpage_overlays(tabid)
   local wincfg
   for _, winid in pairs(api.nvim_tabpage_list_wins(tabid)) do
     wincfg = api.nvim_call_function("getwininfo", {winid})[1]
-    create_overlay_window(winid, filter_wininfo(wincfg))
+    if can_shade(winid) then
+      create_overlay_window(winid, filter_wininfo(wincfg))
+    end
   end
   unshade_window(api.nvim_get_current_win())
 end


### PR DESCRIPTION
Since this was a requested feature (by myself too!) I've decided to implement it.
Right now, it adds a config option "exclude_filetypes" that I've briefly documented in the README.
It's used like this:
```lua
require('shade').config({
    exclude_filetypes = { "neo-tree", ... }
})
```

I'm sorry if it's not the cleanest pull request ever, I've edited the README online, so there is an additional "merge" in there (also, I have nvim setup with 4 spaces indentation, so I needed to fix it in the last commit).