### PR TITLE
fix: handle windows with winbar correctly

### DIFF
--- a/lua/shade.lua
+++ b/lua/shade.lua
@@ -104,7 +104,7 @@ local function filter_wininfo(wininfo)
     row    = wininfo.winrow - 1,
     col    = wininfo.wincol - 1,
     width  = wininfo.width,
-    height = wininfo.height,
+    height = wininfo.height + (wininfo.winbar or 0),
   }
 end
 


### PR DESCRIPTION
Without this change this would happen (the last line is not shaded):

![image](https://user-images.githubusercontent.com/34583604/196020782-bc59853a-ca5e-4dcc-ba62-6b9b17dc3f34.png)